### PR TITLE
Updates default Form.Upload.onComplete to be Safari compatible

### DIFF
--- a/Source/Form.Upload.js
+++ b/Source/Form.Upload.js
@@ -26,7 +26,7 @@ Form.Upload = new Class({
 		fireAtOnce: false,
 		onComplete: function(){
 			// reload
-			window.location.href = window.location.href;
+			window.location.reload();
 		}
 	},
 


### PR DESCRIPTION
Since Safari ist not reloading the page if WL.href is set to the string it already contains I changed the resetting to call the [reload()](https://developer.mozilla.org/en-US/docs/Web/API/Location/reload)-Function on the [Location](https://developer.mozilla.org/en-US/docs/Web/API/Window/location)-Instance.
